### PR TITLE
.npmignore *.ts source files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ manifest.mf
 build.xml
 node_modules/*
 npm-debug.log
+*.ts
 !*.d.ts
 tests
 .github

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ng2-toasty-gamebench",
   "description": "Angular2 Toasty component shows growl-style alerts and messages for your web app - now with more clicking!",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "scripts": {
     "test": "karma start",
     "test-watch": "tsc && karma start --no-single-run --auto-watch",


### PR DESCRIPTION
**Context**:
Right now I'm almost upgraded angular (`4.4.6` -> `5.2.11`) in GameBench WebDashboard.
And this is the only package left that breaks the frontend build.

Somehow the currently published version (`0.0.3`) does not have `*.d.ts` files packaged.

**The idea of this PR**:
Stop shipping `.ts`, shipping `*.d.ts` files is enough

The consumer of this library won't have to compile it's source code
and also user might even have incompatible version of typescript installed